### PR TITLE
gtk-3: gnomeapp-nautilus->add padding for slidebar

### DIFF
--- a/evopop-gtk-theme/gtk-3.0/apps/gnome-applications.css
+++ b/evopop-gtk-theme/gtk-3.0/apps/gnome-applications.css
@@ -31,6 +31,10 @@ NautilusWindow .sidebar .view {
     background-image: none;
 }
 
+NautilusWindow .sidebar-icon {
+    padding: 10px;
+}
+
 NautilusWindow .sidebar .cell:selected,
 NautilusWindow .sidebar .cell:selected:focus {
     border-radius: 0 3px 3px 0;

--- a/evopop-light-gtk-theme/gtk-3.0/apps/gnome-applications.css
+++ b/evopop-light-gtk-theme/gtk-3.0/apps/gnome-applications.css
@@ -31,6 +31,10 @@ NautilusWindow .sidebar .view {
     background-image: none;
 }
 
+NautilusWindow .sidebar-icon {
+    padding: 10px;
+}
+
 NautilusWindow .sidebar .cell:selected,
 NautilusWindow .sidebar .cell:selected:focus {
     border-radius: 0 3px 3px 0;


### PR DESCRIPTION
#### Problem description: 
* The slider-bar-icons are too close to the left border of nautilus window in Ubuntu gnome 16.04 and Fedora 23.

#### Fix:
* add padding for the sliderbar-icons， I just test it in Ubuntu Gnome 16.04 and Fedora 23.